### PR TITLE
7 improve version support

### DIFF
--- a/association/stackconfig.go
+++ b/association/stackconfig.go
@@ -37,12 +37,12 @@ func CheckVersion(searchVersion string, routerVersion string) bool {
 			searchVersion = searchVersion[2:]
 		}
 		// Find out if routerVersion can be reduced
-		logger.Log.Infof("Check router version %s against entry %s - operator is %s", routerVersion, searchVersion, operator)
 		r, _ := regexp.Compile(searchVersion + "*")
 		result := r.FindString(routerVersion)
 		if result != "" {
 			routerVersion = result
 		}
+		logger.Log.Infof("Check router version %s against entry %s - operator is %s", routerVersion, searchVersion, operator)
 
 		switch operator {
 		case "==":
@@ -198,11 +198,14 @@ func ConfigueStack(cfg *config.ConfigContainer, family string) error {
 						}
 					}
 				}
+
 				if confToApply != "" {
 					perVersion[confToApply] = append(perVersion[confToApply], r)
+					logger.Log.Infof("Router with version %s will use configuration %s", r.Version, confToApply)
 				} else {
 					if defaultConfig != "" {
 						perVersion[defaultConfig] = append(perVersion[defaultConfig], r)
+						logger.Log.Infof("Router with version %s will use configuration %s", r.Version, defaultConfig)
 					}
 				}
 			}

--- a/association/stackconfig.go
+++ b/association/stackconfig.go
@@ -198,11 +198,11 @@ func ConfigueStack(cfg *config.ConfigContainer, family string) error {
 
 				if confToApply != "" {
 					perVersion[confToApply] = append(perVersion[confToApply], r)
-					logger.Log.Infof("Router with version %s will use configuration %s", r.Version, confToApply)
+					logger.Log.Infof("Router %s version %s will use configuration %s", r.Shortname, r.Version, confToApply)
 				} else {
 					if defaultConfig != "" {
 						perVersion[defaultConfig] = append(perVersion[defaultConfig], r)
-						logger.Log.Infof("Router with version %s will use configuration %s", r.Version, defaultConfig)
+						logger.Log.Infof("Router %s  version %s will use configuration %s", r.Shortname, r.Version, defaultConfig)
 					}
 				}
 			}

--- a/association/stackconfig.go
+++ b/association/stackconfig.go
@@ -41,8 +41,6 @@ func CheckVersion(searchVersion string, routerVersion string) bool {
 		if result != "" {
 			routerVersion = result
 		}
-		logger.Log.Infof("Check router version %s against entry %s - operator is %s", routerVersion, searchVersion, operator)
-
 		switch operator {
 		case "==":
 			if strings.Compare(routerVersion, searchVersion) == 0 {

--- a/association/stackconfig.go
+++ b/association/stackconfig.go
@@ -27,19 +27,14 @@ const PATH_GRAFANA string = "/var/shared/grafana/dashboards/"
 func CheckVersion(searchVersion string, routerVersion string) bool {
 	var operator string
 
-	logger.Log.Errorf("Check version : %s vs %s", searchVersion, routerVersion)
 	if len(searchVersion) > 2 {
-		logger.Log.Error("here we go")
 		// Search operator
 		if unicode.IsDigit(rune(searchVersion[0])) && unicode.IsDigit(rune(searchVersion[1])) {
 			operator = "=="
-
 		} else {
 			operator = searchVersion[0:2]
 			searchVersion = searchVersion[2:]
 		}
-		logger.Log.Errorf("operator %s", operator)
-
 		// Find out if routerVersion can be reduced
 		r, _ := regexp.Compile(searchVersion + "*")
 		result := r.FindString(routerVersion)
@@ -196,7 +191,6 @@ func ConfigueStack(cfg *config.ConfigContainer, family string) error {
 					if c.Version == "all" {
 						defaultConfig = c.Config
 					} else {
-						logger.Log.Errorf("debug: %v", c)
 						result := CheckVersion(c.Version, r.Version)
 						if result && (confToApply == "") {
 							confToApply = c.Config

--- a/association/stackconfig.go
+++ b/association/stackconfig.go
@@ -27,6 +27,7 @@ const PATH_GRAFANA string = "/var/shared/grafana/dashboards/"
 func CheckVersion(searchVersion string, routerVersion string) bool {
 	var operator string
 
+	logger.Log.Errorf("Check version : %s vs %s", searchVersion, routerVersion)
 	if len(searchVersion) > 2 {
 		// Search operator
 		if unicode.IsDigit(rune(searchVersion[0])) && unicode.IsDigit(rune(searchVersion[1])) {

--- a/association/stackconfig.go
+++ b/association/stackconfig.go
@@ -29,6 +29,7 @@ func CheckVersion(searchVersion string, routerVersion string) bool {
 
 	logger.Log.Errorf("Check version : %s vs %s", searchVersion, routerVersion)
 	if len(searchVersion) > 2 {
+		logger.Log.Error("here we go")
 		// Search operator
 		if unicode.IsDigit(rune(searchVersion[0])) && unicode.IsDigit(rune(searchVersion[1])) {
 			operator = "=="
@@ -37,6 +38,8 @@ func CheckVersion(searchVersion string, routerVersion string) bool {
 			operator = searchVersion[0:2]
 			searchVersion = searchVersion[2:]
 		}
+		logger.Log.Errorf("operator %s", operator)
+
 		// Find out if routerVersion can be reduced
 		r, _ := regexp.Compile(searchVersion + "*")
 		result := r.FindString(routerVersion)

--- a/association/stackconfig.go
+++ b/association/stackconfig.go
@@ -46,23 +46,29 @@ func CheckVersion(searchVersion string, routerVersion string) bool {
 		switch operator {
 		case "==":
 			if strings.Compare(routerVersion, searchVersion) == 0 {
+				logger.Log.Infof("Config apply is: %s", searchVersion)
 				return true
 			}
 
 		case ">>":
 			if strings.Compare(routerVersion, searchVersion) > 0 {
+				logger.Log.Infof("Config apply is: %s", searchVersion)
 				return true
 			}
 		case "<<":
 			if strings.Compare(routerVersion, searchVersion) < 0 {
+				logger.Log.Infof("Config apply is: %s", searchVersion)
 				return true
+
 			}
 		case ">=":
 			if strings.Compare(routerVersion, searchVersion) >= 0 {
+				logger.Log.Infof("Config apply is: %s", searchVersion)
 				return true
 			}
 		case "<=":
 			if strings.Compare(routerVersion, searchVersion) <= 0 {
+				logger.Log.Infof("Config apply is: %s", searchVersion)
 				return true
 			}
 		default:

--- a/association/stackconfig.go
+++ b/association/stackconfig.go
@@ -192,6 +192,7 @@ func ConfigueStack(cfg *config.ConfigContainer, family string) error {
 					if c.Version == "all" {
 						defaultConfig = c.Config
 					} else {
+						logger.Log.Errorf("debug: %v", c)
 						result := CheckVersion(c.Version, r.Version)
 						if result && (confToApply == "") {
 							confToApply = c.Config

--- a/association/stackconfig.go
+++ b/association/stackconfig.go
@@ -193,7 +193,7 @@ func ConfigueStack(cfg *config.ConfigContainer, family string) error {
 						defaultConfig = c.Config
 					} else {
 						result := CheckVersion(c.Version, r.Version)
-						if result && confToApply == "" {
+						if result && (confToApply == "") {
 							confToApply = c.Config
 						}
 					}

--- a/association/stackconfig.go
+++ b/association/stackconfig.go
@@ -8,9 +8,11 @@ import (
 	"jtso/logger"
 	"jtso/sqlite"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"text/template"
+	"unicode"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
@@ -21,6 +23,55 @@ const PATH_MX string = "/var/shared/telegraf/mx/telegraf.d/"
 const PATH_PTX string = "/var/shared//telegraf/ptx/telegraf.d/"
 const PATH_ACX string = "/var/shared//telegraf/acx/telegraf.d/"
 const PATH_GRAFANA string = "/var/shared/grafana/dashboards/"
+
+func CheckVersion(searchVersion string, routerVersion string) bool {
+	var operator string
+
+	if len(searchVersion) > 2 {
+		// Search operator
+		if unicode.IsDigit(rune(searchVersion[0])) && unicode.IsDigit(rune(searchVersion[1])) {
+			operator = "=="
+
+		} else {
+			operator = searchVersion[0:2]
+			searchVersion = searchVersion[2:]
+		}
+		// Find out if routerVersion can be reduced
+		r, _ := regexp.Compile(searchVersion + "*")
+		result := r.FindString(routerVersion)
+		if result != "" {
+			routerVersion = result
+		}
+
+		switch operator {
+		case "==":
+			if strings.Compare(routerVersion, searchVersion) == 0 {
+				return true
+			}
+
+		case ">>":
+			if strings.Compare(routerVersion, searchVersion) > 0 {
+				return true
+			}
+		case "<<":
+			if strings.Compare(routerVersion, searchVersion) < 0 {
+				return true
+			}
+		case ">=":
+			if strings.Compare(routerVersion, searchVersion) >= 0 {
+				return true
+			}
+		case "<=":
+			if strings.Compare(routerVersion, searchVersion) <= 0 {
+				return true
+			}
+		default:
+			return false
+		}
+	}
+	return false
+
+}
 
 func ConfigueStack(cfg *config.ConfigContainer, family string) error {
 
@@ -103,8 +154,7 @@ func ConfigueStack(cfg *config.ConfigContainer, family string) error {
 		for p, rtrs := range cfgHierarchy[f] {
 
 			var filenames []Config
-			var perVersion map[string][]*sqlite.RtrEntry
-			perVersion = make(map[string][]*sqlite.RtrEntry)
+			perVersion := make(map[string][]*sqlite.RtrEntry)
 
 			// extract definition of the profile
 			switch f {
@@ -132,28 +182,28 @@ func ConfigueStack(cfg *config.ConfigContainer, family string) error {
 
 			// Create the map - per version > routers
 			for _, r := range rtrs {
-				keep_version := "all"
-				save_conf := ""
+				confToApply := ""
+				defaultConfig := ""
+
 				for _, c := range filenames {
-					if c.Version != "all" {
-						comp := strings.Compare(r.Version, c.Version)
-						if comp == -1 {
-							if keep_version != "all" {
-								comp := strings.Compare(c.Version, keep_version)
-								if comp == -1 {
-									keep_version = c.Version
-									save_conf = c.Config
-								}
-							} else {
-								keep_version = c.Version
-								save_conf = c.Config
-							}
-						}
+					// Save all config if present as a fallback solution if specific version not found
+					if c.Version == "all" {
+						defaultConfig = c.Config
 					} else {
-						save_conf = c.Config
+						result := CheckVersion(c.Version, r.Version)
+						if result && confToApply == "" {
+							confToApply = c.Config
+							break
+						}
 					}
 				}
-				perVersion[save_conf] = append(perVersion[save_conf], r)
+				if confToApply != "" {
+					perVersion[confToApply] = append(perVersion[confToApply], r)
+				} else {
+					if defaultConfig != "" {
+						perVersion[defaultConfig] = append(perVersion[defaultConfig], r)
+					}
+				}
 			}
 
 			for filename, v := range perVersion {

--- a/association/stackconfig.go
+++ b/association/stackconfig.go
@@ -37,6 +37,7 @@ func CheckVersion(searchVersion string, routerVersion string) bool {
 			searchVersion = searchVersion[2:]
 		}
 		// Find out if routerVersion can be reduced
+		logger.Log.Infof("Check router version %s against entry %s - operator is %s", routerVersion, searchVersion, operator)
 		r, _ := regexp.Compile(searchVersion + "*")
 		result := r.FindString(routerVersion)
 		if result != "" {
@@ -46,29 +47,24 @@ func CheckVersion(searchVersion string, routerVersion string) bool {
 		switch operator {
 		case "==":
 			if strings.Compare(routerVersion, searchVersion) == 0 {
-				logger.Log.Infof("Config apply is: %s", searchVersion)
 				return true
 			}
 
 		case ">>":
 			if strings.Compare(routerVersion, searchVersion) > 0 {
-				logger.Log.Infof("Config apply is: %s", searchVersion)
 				return true
 			}
 		case "<<":
 			if strings.Compare(routerVersion, searchVersion) < 0 {
-				logger.Log.Infof("Config apply is: %s", searchVersion)
 				return true
 
 			}
 		case ">=":
 			if strings.Compare(routerVersion, searchVersion) >= 0 {
-				logger.Log.Infof("Config apply is: %s", searchVersion)
 				return true
 			}
 		case "<=":
 			if strings.Compare(routerVersion, searchVersion) <= 0 {
-				logger.Log.Infof("Config apply is: %s", searchVersion)
 				return true
 			}
 		default:
@@ -199,7 +195,6 @@ func ConfigueStack(cfg *config.ConfigContainer, family string) error {
 						result := CheckVersion(c.Version, r.Version)
 						if result && confToApply == "" {
 							confToApply = c.Config
-							break
 						}
 					}
 				}

--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,8 @@ import (
 	"github.com/spf13/viper"
 )
 
+const JTSO_VERSION string = "1.0.1"
+
 type PortalConfig struct {
 	Https     bool
 	ServerCrt string

--- a/html/templates/index.html
+++ b/html/templates/index.html
@@ -550,7 +550,7 @@
                 </svg>
                 </br>
             </div>
-            <i><h7 class="card-title">JTS Version - 1.0.0 - JTSO Version 1.0.1 - JTS Telegraf 1.0.0</h7></i>
+            <i><p style="font-size: 0.8rem;">JTS Version - 1.0.0 - JTSO Version 1.0.1 - JTS Telegraf 1.0.0</p></i>
         </div>
     </div>
     <script src="js/alertify.min.js"></script>

--- a/html/templates/index.html
+++ b/html/templates/index.html
@@ -557,7 +557,6 @@
     <script src="js/jquery-3.6.4.min.js"></script>
     <script src="bootstrap/js/bootstrap.min.js"></script>
     <script src="js/main.js"></script>
-
 </body>
 
 </html>

--- a/html/templates/index.html
+++ b/html/templates/index.html
@@ -550,7 +550,7 @@
                 </svg>
                 </br>
             </div>
-            <i><h6 class="card-title">Version 1.0.1</h6></i>
+            <i><h7 class="card-title">JTS Version - 1.0.0 - JTSO Version 1.0.1 - JTS Telegraf 1.0.0</h7></i>
         </div>
     </div>
     <script src="js/alertify.min.js"></script>

--- a/html/templates/index.html
+++ b/html/templates/index.html
@@ -550,6 +550,7 @@
                 </svg>
                 </br>
             </div>
+            <i><h6 class="card-title">Version 1.0.1</h6></i>
         </div>
     </div>
     <script src="js/alertify.min.js"></script>

--- a/html/templates/index.html
+++ b/html/templates/index.html
@@ -550,7 +550,7 @@
                 </svg>
                 </br>
             </div>
-            <i><p style="font-size: 0.8rem;">JTS Version - 1.0.0 - JTSO Version 1.0.1 - JTS Telegraf 1.0.0</p></i>
+            <i><p style="font-size: 0.8rem;">JTS Version - {{.JTS_VERS}} - JTSO Version {{.JTSO_VERS}} - JTS Telegraf {{.JTS_TELE_VERS}}</p></i>
         </div>
     </div>
     <script src="js/alertify.min.js"></script>

--- a/portal/webapp.go
+++ b/portal/webapp.go
@@ -407,20 +407,44 @@ func routeAddProfile(c echo.Context) error {
 		allTele := association.ActiveProfiles[i].Definition.TelCfg
 		switch fam {
 		case "vmx":
-			if len(allTele.VmxCfg) == 0 || !checkRouterSupport(allTele.VmxCfg, version) {
+			if len(allTele.VmxCfg) == 0 {
 				errString += "There is no Telegraf config for profile " + i + " for the VMX platform.</br>"
+			} else {
+				if checkRouterSupport(allTele.VmxCfg, version) {
+					valid = true
+				} else {
+					errString += "There is no Telegraf config for profile " + i + " for this VMX version.</br>"
+				}
 			}
 		case "mx":
-			if len(allTele.MxCfg) == 0 || !checkRouterSupport(allTele.MxCfg, version) {
+			if len(allTele.MxCfg) == 0 {
 				errString += "There is no Telegraf config for profile " + i + " for the MX platform.</br>"
+			} else {
+				if checkRouterSupport(allTele.MxCfg, version) {
+					valid = true
+				} else {
+					errString += "There is no Telegraf config for profile " + i + " for this MX version.</br>"
+				}
 			}
 		case "ptx":
-			if len(allTele.PtxCfg) == 0 || !checkRouterSupport(allTele.PtxCfg, version) {
+			if len(allTele.PtxCfg) == 0 {
 				errString += "There is no Telegraf config for profile " + i + " for the PTX platform.</br>"
+			} else {
+				if checkRouterSupport(allTele.PtxCfg, version) {
+					valid = true
+				} else {
+					errString += "There is no Telegraf config for profile " + i + " for this PTX version.</br>"
+				}
 			}
 		case "acx":
-			if len(allTele.AcxCfg) == 0 || !checkRouterSupport(allTele.AcxCfg, version) {
+			if len(allTele.AcxCfg) == 0 {
 				errString += "There is no Telegraf config for profile " + i + " for the ACX platform.</br>"
+			} else {
+				if checkRouterSupport(allTele.AcxCfg, version) {
+					valid = true
+				} else {
+					errString += "There is no Telegraf config for profile " + i + " for this ACX version.</br>"
+				}
 			}
 		default:
 			errString += "There is no Telegraf config for profile " + i + " for the unknown platform.</br>"

--- a/portal/webapp.go
+++ b/portal/webapp.go
@@ -402,7 +402,8 @@ func checkRouterSupport(filenames []association.Config, routerVersion string) bo
 			defaultConfig = c.Config
 		} else {
 			result := association.CheckVersion(c.Version, routerVersion)
-			if result && confToApply == "" {
+			logger.Log.Errorf("result %v", result)
+			if result && (confToApply == "") {
 				return true
 			}
 		}

--- a/portal/webapp.go
+++ b/portal/webapp.go
@@ -30,7 +30,7 @@ import (
 
 const PATH_CERT string = "/var/cert/"
 const PATH_JTS_VERS string = "/etc/jtso/openjts.version"
-const PATH_TELE_VERS string = "/etc/jtso/openjts.version"
+const PATH_TELE_VERS string = "/var/metadata/telegraf.version"
 
 type WebApp struct {
 	listen string

--- a/portal/webapp.go
+++ b/portal/webapp.go
@@ -394,15 +394,12 @@ func routeDelRouter(c echo.Context) error {
 func checkRouterSupport(filenames []association.Config, routerVersion string) bool {
 	confToApply := ""
 	defaultConfig := ""
-	logger.Log.Errorf("Filename %v", filenames)
 	for _, c := range filenames {
-		logger.Log.Errorf("Loop %v", c)
 		// Save all config if present as a fallback solution if specific version not found
 		if c.Version == "all" {
 			defaultConfig = c.Config
 		} else {
 			result := association.CheckVersion(c.Version, routerVersion)
-			logger.Log.Errorf("result %v", result)
 			if result && (confToApply == "") {
 				return true
 			}
@@ -445,8 +442,6 @@ func routeAddProfile(c echo.Context) error {
 			break
 		}
 	}
-
-	logger.Log.Errorf("Router %s", r.Shortname)
 	// Now check for each profile there is a given Telegraf config
 	valid := false
 	errString := ""

--- a/portal/webapp.go
+++ b/portal/webapp.go
@@ -443,6 +443,8 @@ func routeAddProfile(c echo.Context) error {
 			break
 		}
 	}
+
+	logger.Log.Errorf("Router %s", r.Shortname)
 	// Now check for each profile there is a given Telegraf config
 	valid := false
 	errString := ""
@@ -465,6 +467,7 @@ func routeAddProfile(c echo.Context) error {
 			} else {
 				if checkRouterSupport(allTele.MxCfg, version) {
 					valid = true
+					logger.Log.Errorf("Router valid %s", r.Shortname)
 				} else {
 					errString += "There is no Telegraf config for profile " + i + " for this MX version.</br>"
 				}

--- a/portal/webapp.go
+++ b/portal/webapp.go
@@ -1,6 +1,7 @@
 package portal
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -15,6 +16,7 @@ import (
 	"jtso/sqlite"
 	"jtso/worker"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -27,6 +29,8 @@ import (
 )
 
 const PATH_CERT string = "/var/cert/"
+const PATH_JTS_VERS string = "/etc/jtso/openjts.version"
+const PATH_TELE_VERS string = "/etc/jtso/openjts.version"
 
 type WebApp struct {
 	listen string
@@ -186,7 +190,44 @@ func routeIndex(c echo.Context) error {
 		}
 	}
 
-	return c.Render(http.StatusOK, "index.html", map[string]interface{}{"TeleVmx": teleVmx, "TeleMx": teleMx, "TelePtx": telePtx, "TeleAcx": teleAcx, "Grafana": grafana, "Kapacitor": kapacitor, "Influx": influx, "Jtso": jtso, "NumVMX": numVMX, "NumMX": numMX, "NumPTX": numPTX, "NumACX": numACX, "GrafanaPort": grafanaPort})
+	// Retrieve module's version
+	jtsoVersion := config.JTSO_VERSION
+	jtsVersion := "N/A"
+	teleVersion := "N/A"
+
+	// Open the OpenJTS version's file
+	file_jts, err := os.Open(PATH_JTS_VERS)
+	if err != nil {
+		logger.Log.Errorf("Unable to open %s file: %v", PATH_JTS_VERS, err)
+	}
+	defer file_jts.Close()
+	scanner := bufio.NewScanner(file_jts)
+	if scanner.Scan() {
+		jtsVersion = scanner.Text()
+	}
+	// Check for any errors during scanning
+	if err := scanner.Err(); err != nil {
+		logger.Log.Errorf("Unable to parse %s file: %v", PATH_JTS_VERS, err)
+	}
+
+	// Open the Telegraf version's file
+	file_tele, err := os.Open(PATH_TELE_VERS)
+	if err != nil {
+		logger.Log.Errorf("Unable to open %s file: %v", PATH_TELE_VERS, err)
+	}
+	defer file_tele.Close()
+	scanner = bufio.NewScanner(file_tele)
+	if scanner.Scan() {
+		teleVersion = scanner.Text()
+	}
+	// Check for any errors during scanning
+	if err := scanner.Err(); err != nil {
+		logger.Log.Errorf("Unable to parse %s file: %v", PATH_TELE_VERS, err)
+	}
+
+	return c.Render(http.StatusOK, "index.html", map[string]interface{}{"TeleVmx": teleVmx, "TeleMx": teleMx, "TelePtx": telePtx, "TeleAcx": teleAcx,
+		"Grafana": grafana, "Kapacitor": kapacitor, "Influx": influx, "Jtso": jtso, "NumVMX": numVMX, "NumMX": numMX, "NumPTX": numPTX, "NumACX": numACX,
+		"GrafanaPort": grafanaPort, "JTS_VERS": jtsVersion, "JTSO_VERS": jtsoVersion, "JTS_TELE_VERS": teleVersion})
 }
 
 func routeRouters(c echo.Context) error {

--- a/portal/webapp.go
+++ b/portal/webapp.go
@@ -199,30 +199,32 @@ func routeIndex(c echo.Context) error {
 	file_jts, err := os.Open(PATH_JTS_VERS)
 	if err != nil {
 		logger.Log.Errorf("Unable to open %s file: %v", PATH_JTS_VERS, err)
-	}
-	defer file_jts.Close()
-	scanner := bufio.NewScanner(file_jts)
-	if scanner.Scan() {
-		jtsVersion = scanner.Text()
-	}
-	// Check for any errors during scanning
-	if err := scanner.Err(); err != nil {
-		logger.Log.Errorf("Unable to parse %s file: %v", PATH_JTS_VERS, err)
+	} else {
+		defer file_jts.Close()
+		scanner := bufio.NewScanner(file_jts)
+		if scanner.Scan() {
+			jtsVersion = scanner.Text()
+		}
+		// Check for any errors during scanning
+		if err := scanner.Err(); err != nil {
+			logger.Log.Errorf("Unable to parse %s file: %v", PATH_JTS_VERS, err)
+		}
 	}
 
 	// Open the Telegraf version's file
 	file_tele, err := os.Open(PATH_TELE_VERS)
 	if err != nil {
 		logger.Log.Errorf("Unable to open %s file: %v", PATH_TELE_VERS, err)
-	}
-	defer file_tele.Close()
-	scanner = bufio.NewScanner(file_tele)
-	if scanner.Scan() {
-		teleVersion = scanner.Text()
-	}
-	// Check for any errors during scanning
-	if err := scanner.Err(); err != nil {
-		logger.Log.Errorf("Unable to parse %s file: %v", PATH_TELE_VERS, err)
+	} else {
+		defer file_tele.Close()
+		scanner := bufio.NewScanner(file_tele)
+		if scanner.Scan() {
+			teleVersion = scanner.Text()
+		}
+		// Check for any errors during scanning
+		if err := scanner.Err(); err != nil {
+			logger.Log.Errorf("Unable to parse %s file: %v", PATH_TELE_VERS, err)
+		}
 	}
 
 	return c.Render(http.StatusOK, "index.html", map[string]interface{}{"TeleVmx": teleVmx, "TeleMx": teleMx, "TelePtx": telePtx, "TeleAcx": teleAcx,

--- a/portal/webapp.go
+++ b/portal/webapp.go
@@ -464,7 +464,6 @@ func routeAddProfile(c echo.Context) error {
 			} else {
 				if checkRouterSupport(allTele.MxCfg, version) {
 					valid = true
-					logger.Log.Errorf("Router valid %s", r.Shortname)
 				} else {
 					errString += "There is no Telegraf config for profile " + i + " for this MX version.</br>"
 				}

--- a/portal/webapp.go
+++ b/portal/webapp.go
@@ -394,8 +394,9 @@ func routeDelRouter(c echo.Context) error {
 func checkRouterSupport(filenames []association.Config, routerVersion string) bool {
 	confToApply := ""
 	defaultConfig := ""
-
+	logger.Log.Errorf("Filename %v", filenames)
 	for _, c := range filenames {
+		logger.Log.Errorf("Loop %v", c)
 		// Save all config if present as a fallback solution if specific version not found
 		if c.Version == "all" {
 			defaultConfig = c.Config


### PR DESCRIPTION
Add version information on the main page to better track the version used by users during issues

Improve the per-profile versioning feature on JTSO. Now per platform, we support these operators to find out the config to apply depending on the router’s version:

- == The router’s version must match exactly this profile version 
- <=  The router’s version must match exactly or be lower than this profile version 
- >=  The router’s version must match exactly or be higher than this profile version 
- <<  The router’s version must be strictly lower than this profile version 
- >>  The router’s version must be strictly higher than this profile version 
